### PR TITLE
Add warning with noEmitOnError enabled

### DIFF
--- a/src/tsc-silent.ts
+++ b/src/tsc-silent.ts
@@ -126,7 +126,7 @@ if (argv.watch) {
     const emitResult = program.emit();
 
     if (configParseResult.options.noEmitOnError) {
-      console.warn('You have `noEmitOnError` enabled, if any error occurs TypeScript will not generate any JavaScript output files.');
+      console.warn('You have `noEmitOnError` enabled, if any error occurs TypeScript will not generate any JavaScript output files even if `tsc-silent` exits with 0.');
     }
 
     process.exit(

--- a/src/tsc-silent.ts
+++ b/src/tsc-silent.ts
@@ -124,6 +124,11 @@ if (argv.watch) {
     };
     const program = ts.createProgram(programOptions);
     const emitResult = program.emit();
+
+    if (configParseResult.options.noEmitOnError) {
+      console.warn('You have `noEmitOnError` enabled, if any error occurs TypeScript will not generate any JavaScript output files.');
+    }
+
     process.exit(
         assertDiagnostics(ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics), compilerHost),
     );


### PR DESCRIPTION
Implements the suggestion in #6 to warn when the user has `noEmitOnError` enabled.

When it is enabled an output like this will be provided:

```
yarn run v1.22.11
$ tsc-silent --project tsconfig.json --suppressConfig tsc-silent.config.ts
Using TypeScript compiler version 4.3.2 from ./node_modules/typescript/lib/typescript.js
You have `noEmitOnError` enabled, if any error occurs TypeScript will not generate any JavaScript output files.
Visible errors: 0, suppressed errors: 69
✨  Done in 19.15s.
```